### PR TITLE
feat(sse): implement multiplexed SSE messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,12 +123,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
  "num-traits",
  "serde",
  "winapi",
@@ -610,7 +616,7 @@ dependencies = [
 [[package]]
 name = "model"
 version = "0.1.0"
-source = "git+https://github.com/drippy-iot/model.git#52e2a2a520d4736b063e799edef4a69167782861"
+source = "git+https://github.com/drippy-iot/model.git#71c0a672ae401759b36fb93798ca996d195218d6"
 dependencies = [
  "bitcode",
  "postgres-types",
@@ -641,16 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "openssl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,8 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "serde",
+ "serde_json",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ default-features = false
 
 [dependencies.tokio-postgres]
 version = "0.7"
-features = ["with-uuid-1", "with-chrono-0_4"]
+features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"]
 
 [dependencies.tokio-stream]
 version = "0.1"

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,4 +1,4 @@
-use crate::model::ClientFlow;
+use crate::model::{ClientFlow, UserMessage};
 
 use chrono::{DateTime, Utc};
 use futures_util::{Stream, StreamExt, TryStreamExt};
@@ -161,7 +161,7 @@ impl Database {
             .map(Result::unwrap)
     }
 
-    pub async fn get_metrics_since(&self, mac: MacAddress, since: DateTime<Utc>) {
+    pub async fn get_metrics_since(&self, mac: MacAddress, since: DateTime<Utc>) -> Vec<UserMessage> {
         let row = self.db
             .query_one(
                 "WITH _ AS (\
@@ -175,6 +175,6 @@ impl Database {
             )
             .await
             .unwrap();
-        let jsons = row.get(0);
+        row.get(0)
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -175,6 +175,7 @@ impl Database {
             )
             .await
             .unwrap();
-        row.get(0)
+        let val = row.get(0);
+        serde_json::from_value(val).unwrap()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![no_std]
-
-extern crate alloc;
-
 pub mod database;
-pub mod router;
 pub mod model;
+pub mod router;

--- a/src/model.rs
+++ b/src/model.rs
@@ -12,13 +12,11 @@ pub enum Payload {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct Message<Header> {
-    pub head: Header,
+pub struct UserMessage {
+    pub creation: DateTime<Utc>,
     #[serde(flatten)]
     pub data: Payload,
 }
-
-pub type UserMessage = Message<DateTime<Utc>>;
 
 impl<'a> FromSql<'a> for UserMessage {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
 use chrono::{serde::ts_milliseconds, DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio_postgres::types::{accepts, FromSql, Type};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -13,10 +14,21 @@ pub enum Payload {
 #[derive(Deserialize, Serialize)]
 pub struct Message<Header> {
     pub head: Header,
+    #[serde(flatten)]
     pub data: Payload,
 }
 
 pub type UserMessage = Message<DateTime<Utc>>;
+
+impl<'a> FromSql<'a> for UserMessage {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        assert_eq!(*ty, Type::JSON);
+        let payload = serde_json::from_slice(raw)?;
+        Ok(payload)
+    }
+
+    accepts!(JSON);
+}
 
 #[derive(Serialize)]
 pub struct ClientFlow {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
 use chrono::{serde::ts_milliseconds, DateTime, Utc};
 use model::MacAddress;
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 
 fn mac_to_int<S: Serializer>(mac: &Option<MacAddress>, serializer: S) -> Result<S::Ok, S::Error> {
     if let Some(MacAddress([a, b, c, d, e, f])) = *mac {
@@ -11,7 +11,7 @@ fn mac_to_int<S: Serializer>(mac: &Option<MacAddress>, serializer: S) -> Result<
     }
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Header {
     /// MAC address to which the metrics is associated with.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -21,17 +21,16 @@ pub struct Header {
     pub timestamp: DateTime<Utc>,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[serde(tag = "ty")]
 pub enum Payload {
     Flow { flow: u16 },
+    Control { shutdown: bool },
     Leak,
-    Shutdown,
-    Reset,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Message {
     pub head: Header,
     pub data: Payload,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,25 +1,5 @@
 use chrono::{serde::ts_milliseconds, DateTime, Utc};
-use model::MacAddress;
-use serde::{Deserialize, Serialize, Serializer};
-
-fn mac_to_int<S: Serializer>(mac: &Option<MacAddress>, serializer: S) -> Result<S::Ok, S::Error> {
-    if let Some(MacAddress([a, b, c, d, e, f])) = *mac {
-        let value = u64::from_be_bytes([0, 0, a, b, c, d, e, f]);
-        serializer.serialize_some(&value)
-    } else {
-        serializer.serialize_none()
-    }
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct Header {
-    /// MAC address to which the metrics is associated with.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(serialize_with = "mac_to_int")]
-    pub mac: Option<MacAddress>,
-    /// Exact time of the snapshot.
-    pub timestamp: DateTime<Utc>,
-}
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -31,10 +11,12 @@ pub enum Payload {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct Message {
+pub struct Message<Header> {
     pub head: Header,
     pub data: Payload,
 }
+
+pub type UserMessage = Message<DateTime<Utc>>;
 
 #[derive(Serialize)]
 pub struct ClientFlow {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,4 @@
-use chrono::{serde::ts_milliseconds, DateTime, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio_postgres::types::{accepts, FromSql, Type};
 
@@ -27,13 +27,4 @@ impl<'a> FromSql<'a> for UserMessage {
     }
 
     accepts!(JSON);
-}
-
-#[derive(Serialize)]
-pub struct ClientFlow {
-    // Creation data of the data point
-    #[serde(with = "ts_milliseconds")]
-    pub creation: DateTime<Utc>,
-    // Flow rate of a device at a given time.
-    pub flow: u16,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,43 @@
 use chrono::{serde::ts_milliseconds, DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use model::MacAddress;
+use serde::{Serialize, Serializer};
 
-#[derive(Serialize, Deserialize)]
+fn mac_to_int<S: Serializer>(mac: &Option<MacAddress>, serializer: S) -> Result<S::Ok, S::Error> {
+    if let Some(MacAddress([a, b, c, d, e, f])) = *mac {
+        let value = u64::from_be_bytes([0, 0, a, b, c, d, e, f]);
+        serializer.serialize_some(&value)
+    } else {
+        serializer.serialize_none()
+    }
+}
+
+#[derive(Serialize)]
+pub struct Header {
+    /// MAC address to which the metrics is associated with.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(serialize_with = "mac_to_int")]
+    pub mac: Option<MacAddress>,
+    /// Exact time of the snapshot.
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+#[serde(tag = "ty")]
+pub enum Payload {
+    Flow { flow: u16 },
+    Leak,
+    Shutdown,
+    Reset,
+}
+
+#[derive(Serialize)]
+pub struct Message {
+    pub head: Header,
+    pub data: Payload,
+}
+
+#[derive(Serialize)]
 pub struct ClientFlow {
     // Creation data of the data point
     #[serde(with = "ts_milliseconds")]

--- a/src/model.rs
+++ b/src/model.rs
@@ -13,6 +13,7 @@ pub enum Payload {
 
 #[derive(Deserialize, Serialize)]
 pub struct UserMessage {
+    #[serde(rename(serialize = "ts"))]
     pub creation: DateTime<Utc>,
     #[serde(flatten)]
     pub data: Payload,

--- a/src/router.rs
+++ b/src/router.rs
@@ -207,7 +207,7 @@ impl Router {
                         log::trace!("no active listeners for unit {mac}");
                     }
 
-                    *res.status_mut() = if shutdown { StatusCode::ACCEPTED } else { StatusCode::OK };
+                    *res.status_mut() = if shutdown { StatusCode::OK } else { StatusCode::ACCEPTED };
                     log::info!("session {fmt} requested shutdown of unit {mac}");
                     Ok(res)
                 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -169,8 +169,8 @@ impl Router {
                     };
 
                     let mut res = Response::new(Either::Left(Default::default()));
-                    let (timestamp, shutdown) = self.db.request_shutdown(mac).await;
-                    let message = UserMessage { head: timestamp, data: Payload::Control { shutdown: true } };
+                    let (creation, shutdown) = self.db.request_shutdown(mac).await;
+                    let message = UserMessage { creation, data: Payload::Control { shutdown: true } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {
@@ -196,8 +196,8 @@ impl Router {
                     };
 
                     let mut res = Response::new(Either::Left(Default::default()));
-                    let (timestamp, shutdown) = self.db.request_reset(mac).await;
-                    let message = UserMessage { head: timestamp, data: Payload::Control { shutdown: false } };
+                    let (creation, shutdown) = self.db.request_reset(mac).await;
+                    let message = UserMessage { creation, data: Payload::Control { shutdown: false } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {
@@ -244,8 +244,8 @@ impl Router {
                     let Flow { addr, flow: data } = flow;
                     log::info!("unit {addr} reported {data} ticks");
 
-                    let (timestamp, shutdown) = self.db.report_flow(flow).await;
-                    let message = UserMessage { head: timestamp, data: Payload::Flow { flow: data } };
+                    let (creation, shutdown) = self.db.report_flow(flow).await;
+                    let message = UserMessage { creation, data: Payload::Flow { flow: data } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((addr, json)) {
@@ -266,8 +266,8 @@ impl Router {
 
                     log::warn!("leak detected from {mac}");
 
-                    let (timestamp, shutdown) = self.db.report_leak(mac).await;
-                    let message = UserMessage { head: timestamp, data: Payload::Leak };
+                    let (creation, shutdown) = self.db.report_leak(mac).await;
+                    let message = UserMessage { creation, data: Payload::Leak };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::Database,
-    model::{Header, Message, Payload},
+    model::{UserMessage, Payload},
 };
 
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
@@ -170,8 +170,7 @@ impl Router {
 
                     let mut res = Response::new(Either::Left(Default::default()));
                     let (timestamp, shutdown) = self.db.request_shutdown(mac).await;
-                    let message =
-                        Message { head: Header { mac: None, timestamp }, data: Payload::Control { shutdown: true } };
+                    let message = UserMessage { head: timestamp, data: Payload::Control { shutdown: true } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {
@@ -198,8 +197,7 @@ impl Router {
 
                     let mut res = Response::new(Either::Left(Default::default()));
                     let (timestamp, shutdown) = self.db.request_reset(mac).await;
-                    let message =
-                        Message { head: Header { mac: None, timestamp }, data: Payload::Control { shutdown: false } };
+                    let message = UserMessage { head: timestamp, data: Payload::Control { shutdown: false } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {
@@ -247,7 +245,7 @@ impl Router {
                     log::info!("unit {addr} reported {data} ticks");
 
                     let (timestamp, shutdown) = self.db.report_flow(flow).await;
-                    let message = Message { head: Header { mac: None, timestamp }, data: Payload::Flow { flow: data } };
+                    let message = UserMessage { head: timestamp, data: Payload::Flow { flow: data } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((addr, json)) {
@@ -269,7 +267,7 @@ impl Router {
                     log::warn!("leak detected from {mac}");
 
                     let (timestamp, shutdown) = self.db.report_leak(mac).await;
-                    let message = Message { head: Header { mac: None, timestamp }, data: Payload::Leak };
+                    let message = UserMessage { head: timestamp, data: Payload::Leak };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {

--- a/src/router.rs
+++ b/src/router.rs
@@ -166,8 +166,8 @@ impl Router {
                     };
 
                     let mut res = Response::new(Either::Left(Default::default()));
-                    *res.status_mut() =
-                        if self.db.request_shutdown(mac).await { StatusCode::ACCEPTED } else { StatusCode::OK };
+                    let (creation, shutdown) = self.db.request_shutdown(mac).await;
+                    *res.status_mut() = if shutdown { StatusCode::ACCEPTED } else { StatusCode::OK };
                     log::info!("session {fmt} requested shutdown of unit {mac}");
                     Ok(res)
                 }
@@ -232,11 +232,8 @@ impl Router {
                     log::warn!("leak detected from {mac}");
 
                     let mut res = Response::new(Either::Left(Default::default()));
-                    *res.status_mut() = if self.db.report_leak(mac).await {
-                        StatusCode::SERVICE_UNAVAILABLE
-                    } else {
-                        StatusCode::CREATED
-                    };
+                    let (creation, shutdown) = self.db.report_leak(mac).await;
+                    *res.status_mut() = if shutdown { StatusCode::SERVICE_UNAVAILABLE } else { StatusCode::CREATED };
 
                     Ok(res)
                 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -170,7 +170,8 @@ impl Router {
 
                     let mut res = Response::new(Either::Left(Default::default()));
                     let (timestamp, shutdown) = self.db.request_shutdown(mac).await;
-                    let message = Message { head: Header { mac: None, timestamp }, data: Payload::Shutdown };
+                    let message =
+                        Message { head: Header { mac: None, timestamp }, data: Payload::Control { shutdown: true } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {
@@ -197,7 +198,8 @@ impl Router {
 
                     let mut res = Response::new(Either::Left(Default::default()));
                     let (timestamp, shutdown) = self.db.request_reset(mac).await;
-                    let message = Message { head: Header { mac: None, timestamp }, data: Payload::Reset };
+                    let message =
+                        Message { head: Header { mac: None, timestamp }, data: Payload::Control { shutdown: false } };
                     let json = to_sse_message(&message).unwrap();
 
                     if let Ok(receivers) = self.tx.send((mac, json)) {

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,9 +1,8 @@
 use crate::{
     database::Database,
-    model::{UserMessage, Payload},
+    model::{Payload, UserMessage},
 };
 
-use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use cookie::Cookie;
 use core::{convert::Infallible, future::Future};
@@ -17,6 +16,7 @@ use hyper::{
 };
 use model::{decode, report::Flow, MacAddress};
 use serde::Serialize;
+use std::sync::Arc;
 use tokio::sync::broadcast::{channel, Sender};
 use uuid::Uuid;
 
@@ -227,7 +227,7 @@ impl Router {
                     let fmt = uuid.simple();
                     log::info!("created new session {fmt} for unit {mac}");
 
-                    let cookie = alloc::format!("sid={fmt}; HttpOnly; SameSite=None; Secure");
+                    let cookie = format!("sid={fmt}; HttpOnly; SameSite=None; Secure");
                     let cookie = HeaderValue::from_str(&cookie).unwrap();
 
                     let mut res = Response::new(Either::Left(Default::default()));

--- a/src/router.rs
+++ b/src/router.rs
@@ -119,10 +119,11 @@ impl Router {
                         return Err(StatusCode::UNAUTHORIZED);
                     };
 
-                    let data: Vec<_> = self.db.get_flows(mac, start).await.collect().await;
+                    let data = self.db.get_metrics_since(mac, start).await.into_boxed_slice();
                     let fmt = sid.simple();
                     log::info!("session {fmt} retrieved metrics for unit {mac} [{shutdown}]");
                     let json = Frame::data(to_sse_message(&data).unwrap());
+                    drop(data);
 
                     use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
                     let stream = BroadcastStream::new(self.tx.subscribe()).filter_map(move |res| {

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -11,7 +11,6 @@ async fn database_tests() -> anyhow::Result<()> {
     // Generate random MAC address for testing purposes.
     let mut rng = nanorand::WyRand::new();
     let [a, b, c, d, e, f, ..] = rng.rand();
-    drop(rng);
     let addr = MacAddress([a, b, c, d, e, f]);
     let start = chrono::Utc::now();
 

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -71,6 +71,11 @@ async fn database_tests() -> anyhow::Result<()> {
     assert!(start < creation);
     assert!(shutdown);
 
+    // Get all timestamp since the start of these tests
+    let metrics = db.get_metrics_since(addr, start).await.into_boxed_slice();
+    assert_eq!(metrics.len(), 14);
+
+    // Test user login flow
     let id = db.create_session(addr).await.unwrap();
     let (other, shutdown) = db.get_unit_from_session(id).await.unwrap();
     assert_eq!(addr, other);

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -63,6 +63,14 @@ async fn database_tests() -> anyhow::Result<()> {
     assert!(start < creation);
     assert!(!shutdown);
 
+    // Reset from a remote shutdown
+    let (creation, shutdown) = db.request_shutdown(addr).await;
+    assert!(start < creation);
+    assert!(!shutdown);
+    let (creation, shutdown) = db.request_reset(addr).await;
+    assert!(start < creation);
+    assert!(shutdown);
+
     let id = db.create_session(addr).await.unwrap();
     let (other, shutdown) = db.get_unit_from_session(id).await.unwrap();
     assert_eq!(addr, other);

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -22,24 +22,24 @@ async fn database_tests() -> anyhow::Result<()> {
     assert!(!db.register_unit(mac).await); // existing registration
 
     // Ping water flow thrice; no shutdown requests must occur
-    assert!(!db.report_flow(Flow { addr: mac, flow: 50 }).await);
-    assert!(!db.report_flow(Flow { addr: mac, flow: 78 }).await);
-    assert!(!db.report_flow(Flow { addr: mac, flow: 100 }).await);
+    assert!(!db.report_flow(Flow { addr: mac, flow: 50 }).await.1);
+    assert!(!db.report_flow(Flow { addr: mac, flow: 78 }).await.1);
+    assert!(!db.report_flow(Flow { addr: mac, flow: 100 }).await.1);
 
     // Report leaks thrice; no shutdown requests must occur
-    assert!(!db.report_leak(mac).await);
-    assert!(!db.report_leak(mac).await);
-    assert!(!db.report_leak(mac).await);
+    assert!(!db.report_leak(mac).await.1);
+    assert!(!db.report_leak(mac).await.1);
+    assert!(!db.report_leak(mac).await.1);
 
     // Request shutdown when reporting water flow
-    assert!(!db.request_shutdown(mac).await);                    // request
-    assert!(db.report_flow(Flow { addr: mac, flow: 50 }).await); // acknowledge & reset
-    assert!(!db.report_flow(Flow { addr: mac, flow: 0 }).await); // proceed
+    assert!(!db.request_shutdown(mac).await.1);                    // request
+    assert!(db.report_flow(Flow { addr: mac, flow: 50 }).await.1); // acknowledge & reset
+    assert!(!db.report_flow(Flow { addr: mac, flow: 0 }).await.1); // proceed
 
     // Request shutdown when reporting leaks
-    assert!(!db.request_shutdown(mac).await); // request
-    assert!(db.report_leak(mac).await);       // acknowledge & reset
-    assert!(!db.report_leak(mac).await);      // proceed
+    assert!(!db.request_shutdown(mac).await.1); // request
+    assert!(db.report_leak(mac).await.1);       // acknowledge & reset
+    assert!(!db.report_leak(mac).await.1);      // proceed
 
     let id = db.create_session(mac).await.unwrap();
     let (other_mac, shutdown) = db.get_unit_from_session(id).await.unwrap();

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -1,51 +1,73 @@
-use cloud::database::Database;
-use model::{MacAddress, report::Flow};
-use nanorand::{WyRand, Rng};
-use tokio_postgres::NoTls;
-use uuid::Uuid;
+use model::{report::Flow, MacAddress};
+use nanorand::Rng as _;
 
 #[tokio::test]
 async fn database_tests() -> anyhow::Result<()> {
     let url = std::env::var("PG_URL")?.into_boxed_str();
-    let (client, conn) = tokio_postgres::connect(&url, NoTls).await?;
-    let db = Database::from(client);
+    let (client, conn) = tokio_postgres::connect(&url, tokio_postgres::NoTls).await?;
+    let db = cloud::database::Database::from(client);
     let handle = tokio::spawn(conn);
 
     // Generate random MAC address for testing purposes.
-    let mut rng = WyRand::new();
+    let mut rng = nanorand::WyRand::new();
     let [a, b, c, d, e, f, ..] = rng.rand();
     drop(rng);
-    let mac = MacAddress([a, b, c, d, e, f]);
+    let addr = MacAddress([a, b, c, d, e, f]);
+    let start = chrono::Utc::now();
 
     // Register the unit twice just to check if we handle the upsert gracefully
-    assert!(!db.register_unit(mac).await); // first registration
-    assert!(!db.register_unit(mac).await); // existing registration
+    assert!(!db.register_unit(addr).await); // first registration
+    assert!(!db.register_unit(addr).await); // existing registration
 
     // Ping water flow thrice; no shutdown requests must occur
-    assert!(!db.report_flow(Flow { addr: mac, flow: 50 }).await.1);
-    assert!(!db.report_flow(Flow { addr: mac, flow: 78 }).await.1);
-    assert!(!db.report_flow(Flow { addr: mac, flow: 100 }).await.1);
+    let (creation, shutdown) = db.report_flow(Flow { addr, flow: 50 }).await;
+    assert!(start < creation);
+    assert!(!shutdown);
+    let (creation, shutdown) = db.report_flow(Flow { addr, flow: 78 }).await;
+    assert!(start < creation);
+    assert!(!shutdown);
+    let (creation, shutdown) = db.report_flow(Flow { addr, flow: 100 }).await;
+    assert!(start < creation);
+    assert!(!shutdown);
 
     // Report leaks thrice; no shutdown requests must occur
-    assert!(!db.report_leak(mac).await.1);
-    assert!(!db.report_leak(mac).await.1);
-    assert!(!db.report_leak(mac).await.1);
+    let (creation, shutdown) = db.report_leak(addr).await;
+    assert!(start < creation);
+    assert!(!shutdown);
+    let (creation, shutdown) = db.report_leak(addr).await;
+    assert!(start < creation);
+    assert!(!shutdown);
+    let (creation, shutdown) = db.report_leak(addr).await;
+    assert!(start < creation);
+    assert!(!shutdown);
 
     // Request shutdown when reporting water flow
-    assert!(!db.request_shutdown(mac).await.1);                    // request
-    assert!(db.report_flow(Flow { addr: mac, flow: 50 }).await.1); // acknowledge & reset
-    assert!(!db.report_flow(Flow { addr: mac, flow: 0 }).await.1); // proceed
+    let (creation, shutdown) = db.request_shutdown(addr).await; // request
+    assert!(start < creation);
+    assert!(!shutdown);
+    let (creation, shutdown) = db.report_flow(Flow { addr, flow: 48 }).await; // acknowledge & reset
+    assert!(start < creation);
+    assert!(shutdown);
+    let (creation, shutdown) = db.report_flow(Flow { addr, flow: 0 }).await; // proceed
+    assert!(start < creation);
+    assert!(!shutdown);
 
     // Request shutdown when reporting leaks
-    assert!(!db.request_shutdown(mac).await.1); // request
-    assert!(db.report_leak(mac).await.1);       // acknowledge & reset
-    assert!(!db.report_leak(mac).await.1);      // proceed
-
-    let id = db.create_session(mac).await.unwrap();
-    let (other_mac, shutdown) = db.get_unit_from_session(id).await.unwrap();
-    assert_eq!(mac, other_mac);
+    let (creation, shutdown) = db.request_shutdown(addr).await; // request
+    assert!(start < creation);
     assert!(!shutdown);
-    assert!(db.get_unit_from_session(Uuid::nil()).await.is_none());
+    let (creation, shutdown) = db.report_leak(addr).await; // acknowledge & reset
+    assert!(start < creation);
+    assert!(shutdown);
+    let (creation, shutdown) = db.report_leak(addr).await; // proceed
+    assert!(start < creation);
+    assert!(!shutdown);
+
+    let id = db.create_session(addr).await.unwrap();
+    let (other, shutdown) = db.get_unit_from_session(id).await.unwrap();
+    assert_eq!(addr, other);
+    assert!(!shutdown);
+    assert!(db.get_unit_from_session(uuid::Uuid::nil()).await.is_none());
 
     drop(db);
     handle.await??;


### PR DESCRIPTION
This PR implements the unified interface for SSE streams. The new `/api/metrics` endpoint is now an SSE endpoint that streams `UserMessage[]` as its first message followed by individual `UserMessage` objects.

```ts
interface Flow {
    ty: 'flow';
    ts: Date;
    flow: number;
}

interface Leak {
    ty: 'leak';
    ts: Date;
}

interface Control {
    ty: 'control';
    ts: Date;
    shutdown: boolean;
}

export type UserMessage = Flow | Leak | Control;
```