### PR TITLE
refactor!: merge leak detection and flow reporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -604,9 +604,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mio"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "model"
 version = "0.1.0"
-source = "git+https://github.com/drippy-iot/model.git#71c0a672ae401759b36fb93798ca996d195218d6"
+source = "git+https://github.com/drippy-iot/model.git#7354a4a470d79e15370563862d93a39b57fde346"
 dependencies = [
  "bitcode",
  "postgres-types",
@@ -673,9 +673,9 @@ checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -705,9 +705,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",

--- a/db/init.sql
+++ b/db/init.sql
@@ -3,37 +3,30 @@ CREATE EXTENSION pgcrypto;
 -- A single ESP32 unit uniquely identified by its MAC address.
 CREATE TABLE unit(
     mac MACADDR NOT NULL,
-    shutdown BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Keeps track of pending requests (which have not been transmitted
+    -- to the hardware yet). TRUE if open-request. FALSE if close-request.
+    request BOOLEAN DEFAULT NULL,
     PRIMARY KEY (mac)
 );
 
--- Snapshots of the flow rate (ticks per second).
-CREATE TABLE flow(
+-- Ping events containing the flow rate (in ticks per second) and leak detection.
+CREATE TABLE ping(
     mac MACADDR NOT NULL,
     creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     flow SMALLINT NOT NULL,
+    leak BOOLEAN NOT NULL,
     PRIMARY KEY (mac, creation),
-    CONSTRAINT "FK_flow.mac"
+    CONSTRAINT "FK_ping.mac"
         FOREIGN KEY (mac)
         REFERENCES unit (mac)
 );
 
--- Snapshots of the leak events.
-CREATE TABLE leak(
-    mac MACADDR NOT NULL,
-    creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (mac, creation),
-    CONSTRAINT "FK_leak.mac"
-        FOREIGN KEY (mac)
-        REFERENCES unit (mac)
-);
-
--- Snapshots of the control requests (i.e., shutdown and reset).
+-- Snapshots of the bypass requests.
 CREATE TABLE control(
     mac MACADDR NOT NULL,
     creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    -- TRUE if shutdown request and FALSE if reset request.
-    shutdown BOOLEAN NOT NULL,
+    -- TRUE if open-request. FALSE if close-request.
+    request BOOLEAN NOT NULL,
     PRIMARY KEY (mac, creation),
     CONSTRAINT "FK_control.mac"
         FOREIGN KEY (mac)

--- a/src/database.rs
+++ b/src/database.rs
@@ -131,7 +131,7 @@ impl Database {
                     SELECT 'open' AS ty, mac, creation, NULL AS flow, NULL as leak FROM control WHERE request \
                         UNION ALL \
                     SELECT 'close' AS ty, mac, creation, NULL AS flow, NULL as leak FROM control WHERE NOT request \
-                ) SELECT coalesce(json_strip_nulls(json_agg(_)), '[]') AS items FROM _ WHERE mac = $1 AND creation > $2",
+                ) SELECT coalesce(jsonb_strip_nulls(jsonb_agg(_) - 'mac'), '[]') AS items FROM _ WHERE mac = $1 AND creation > $2",
                 &[&mac, &since],
             )
             .await

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,7 @@ use tokio_postgres::types::{accepts, FromSql, Type};
 #[serde(rename_all = "lowercase")]
 #[serde(tag = "ty")]
 pub enum Payload {
-    Flow { flow: u16, leak: bool },
+    Ping { flow: u16, leak: bool },
     Open,
     Close,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,9 +6,9 @@ use tokio_postgres::types::{accepts, FromSql, Type};
 #[serde(rename_all = "lowercase")]
 #[serde(tag = "ty")]
 pub enum Payload {
-    Flow { flow: u16 },
-    Control { shutdown: bool },
-    Leak,
+    Flow { flow: u16, leak: bool },
+    Open,
+    Close,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
Since leak detection and flow reporting happens in lockstep (in the firmware) anyway, this PR merges `POST /report/leak` and `POST /report/flow` into one big endpoint `POST /report/ping`. The ping endpoint returns a status code based on the previous state of the `unit.request` flag. See the code comments for the rationale behind the particular status codes.

The new SSE stream now outputs the new `UserMessage` format:

```typescript
interface Ping {
    ty: 'ping';
    ts: Date;
    flow: number;
    leak: boolean;
}

interface Open {
    ty: 'open';
    ts: Date;
}

interface Close {
    ty: 'close';
    ts: Date;
}

export type UserMessage = Ping | Open | Close;
```