### PR TITLE
feat: implement bypass reporter

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -21,7 +21,7 @@ CREATE TABLE ping(
         REFERENCES unit (mac)
 );
 
--- Snapshots of the bypass requests.
+-- Snapshots of the control events by the PWA.
 CREATE TABLE control(
     mac MACADDR NOT NULL,
     creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -29,6 +29,16 @@ CREATE TABLE control(
     request BOOLEAN NOT NULL,
     PRIMARY KEY (mac, creation),
     CONSTRAINT "FK_control.mac"
+        FOREIGN KEY (mac)
+        REFERENCES unit (mac)
+);
+
+-- Snapshots of the bypass deactivations made by the ESP32.
+CREATE TABLE bypass(
+    mac MACADDR NOT NULL,
+    creation TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (mac, creation),
+    CONSTRAINT "FK_bypass.mac"
         FOREIGN KEY (mac)
         REFERENCES unit (mac)
 );

--- a/src/database.rs
+++ b/src/database.rs
@@ -139,7 +139,8 @@ impl Database {
                     SELECT 'open' AS ty, mac, creation, NULL AS flow, NULL as leak FROM control WHERE request \
                         UNION ALL \
                     SELECT 'close' AS ty, mac, creation, NULL AS flow, NULL as leak FROM control WHERE NOT request \
-                ) SELECT coalesce(jsonb_strip_nulls(jsonb_agg(_) - 'mac'), '[]') AS items FROM _ WHERE mac = $1 AND creation > $2 ORDER BY creation",
+                ), sorted AS (SELECT ty, creation, flow, leak FROM _ WHERE mac = $1 AND creation > $2 GROUP BY ty, creation, flow, leak ORDER BY creation) \
+                SELECT coalesce(jsonb_strip_nulls(jsonb_agg(sorted)), '[]') AS items FROM sorted LIMIT 1",
                 &[&mac, &since],
             )
             .await

--- a/src/database.rs
+++ b/src/database.rs
@@ -90,6 +90,12 @@ impl Database {
         (creation, request)
     }
 
+    /// Reports a bypass deactivation to the server.
+    pub async fn report_bypass(&self, mac: MacAddress) -> DateTime<Utc> {
+        let row = self.db.query_one("INSERT INTO bypass (mac) VALUES ($1) RETURNING creation", &[&mac]).await.unwrap();
+        row.get(0)
+    }
+
     /// Creates a new session from the given address. If the MAC address had not been previously
     /// registered (i.e., the ESP32 failed to ping the server before user logged in), this returns
     /// [`None`]. Otherwise, it returns the [`Uuid`] of the newly created session.
@@ -128,10 +134,12 @@ impl Database {
                 "WITH _ AS (\
                     SELECT 'ping' AS ty, mac, creation, flow, leak FROM ping \
                         UNION ALL \
+                    SELECT 'bypass' AS ty, mac, creation, NULL AS flow, NULL as leak FROM bypass \
+                        UNION ALL \
                     SELECT 'open' AS ty, mac, creation, NULL AS flow, NULL as leak FROM control WHERE request \
                         UNION ALL \
                     SELECT 'close' AS ty, mac, creation, NULL AS flow, NULL as leak FROM control WHERE NOT request \
-                ) SELECT coalesce(jsonb_strip_nulls(jsonb_agg(_) - 'mac'), '[]') AS items FROM _ WHERE mac = $1 AND creation > $2",
+                ) SELECT coalesce(jsonb_strip_nulls(jsonb_agg(_) - 'mac'), '[]') AS items FROM _ WHERE mac = $1 AND creation > $2 ORDER BY creation",
                 &[&mac, &since],
             )
             .await

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,7 @@ pub enum Payload {
     Ping { flow: u16, leak: bool },
     Open,
     Close,
+    Bypass,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/src/router.rs
+++ b/src/router.rs
@@ -286,7 +286,11 @@ impl Router {
                     };
 
                     let Ping { addr, flow: data, leak } = flow;
-                    log::info!("unit {addr} reported {data} ticks");
+                    if leak {
+                        log::warn!("unit {addr} reported {data} ticks with a leak");
+                    } else {
+                        log::info!("unit {addr} reported {data} ticks");
+                    }
 
                     let (creation, state) = self.db.report_ping(flow).await;
                     let message = UserMessage { creation, data: Payload::Ping { flow: data, leak } };

--- a/src/router.rs
+++ b/src/router.rs
@@ -320,6 +320,8 @@ impl Router {
                     };
 
                     let creation = self.db.report_bypass(addr).await;
+                    log::warn!("unit {addr} reported a manual bypass");
+
                     let message = UserMessage { creation, data: Payload::Bypass };
                     let json = to_sse_message(&message).unwrap();
 

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -29,6 +29,14 @@ async fn database_tests() -> anyhow::Result<()> {
     assert!(start < creation);
     assert_eq!(state, None);
 
+    // Hardware should be able to report bypass deactivation
+    let creation = db.report_bypass(addr).await;
+    assert!(start < creation);
+    let creation = db.report_bypass(addr).await;
+    assert!(start < creation);
+    let creation = db.report_bypass(addr).await;
+    assert!(start < creation);
+
     // Report leaks thrice; no shutdown requests must occur
     let (creation, state) = db.report_ping(Ping { addr, flow: 100, leak: true }).await;
     assert!(start < creation);
@@ -86,7 +94,7 @@ async fn database_tests() -> anyhow::Result<()> {
 
     // Get all timestamp since the start of these tests
     let metrics = db.get_metrics_since(addr, start).await.into_boxed_slice();
-    assert_eq!(metrics.len(), 18);
+    assert_eq!(metrics.len(), 21);
 
     // Test user login flow
     let id = db.create_session(addr).await.unwrap();


### PR DESCRIPTION
In response to drippy-iot/metro-tap#5, this PR creates a new endpoint `POST /report/bypass`, which serves as an audit endpoint for bypass deactivation events. This updates the metrics messages as follows:

```ts
interface Ping {
    ty: 'ping';
    ts: Date;
    flow: number;
    leak: boolean;
}

interface Open {
    ty: 'open';
    ts: Date;
}

interface Close {
    ty: 'close';
    ts: Date;
}

interface Bypass {
    ty: 'bypass';
    ts: Date;
}

export type UserMessage = Ping | Open | Close | Bypass;
```