### PR TITLE
feat: implement bucket-based metrics aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -561,9 +561,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "linux-raw-sys"
@@ -573,9 +573,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "model"
 version = "0.1.0"
-source = "git+https://github.com/drippy-iot/model.git#7354a4a470d79e15370563862d93a39b57fde346"
+source = "git+https://github.com/drippy-iot/model.git#2711b2064e107c8738cb2072c9d33ed5b7a93443"
 dependencies = [
  "bitcode",
  "postgres-types",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
@@ -736,22 +736,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "phf"
@@ -843,9 +843,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -887,15 +887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -973,18 +964,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1092,15 +1083,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1114,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
  "serde",
@@ -1422,7 +1414,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1442,35 +1434,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ features = ["derive"]
 
 [dependencies.tokio]
 version = "1.28.1"
-features = ["macros", "net", "parking_lot", "rt-multi-thread", "signal"]
+features = ["macros", "net", "parking_lot", "rt-multi-thread", "signal", "time"]
 default-features = false
 
 [dependencies.tokio-postgres]
@@ -55,7 +55,6 @@ features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"]
 
 [dependencies.tokio-stream]
 version = "0.1"
-features = ["sync"]
 default-features = false
 
 [dependencies.uuid]

--- a/src/database.rs
+++ b/src/database.rs
@@ -131,7 +131,7 @@ impl Database {
     pub async fn get_user_metrics_since(
         &self,
         mac: MacAddress,
-        secs: u32,
+        secs: f64,
         since: DateTime<Utc>,
     ) -> impl Stream<Item = Flow> {
         use futures_util::StreamExt as _;
@@ -140,12 +140,16 @@ impl Database {
             .db
             .query_raw(
                 "WITH _ AS (\
-                    SELECT generate_series($3, NOW(), make_interval(secs => $2)) AS end) EXCEPT SELECT $3\
-                ) SELECT DISTINCT end, COALESCE(AVG(flow) OVER (ORDER BY end RANGE BETWEEN make_interval(secs => $2) PRECEDING AND CURRENT ROW), 0)::REAL AS mean \
+                    SELECT generate_series($3, NOW(), make_interval(secs => $2)) AS endpoint EXCEPT ALL SELECT $3\
+                ) SELECT DISTINCT \
+                    endpoint, \
+                    COALESCE(\
+                        AVG(flow) OVER (ORDER BY endpoint RANGE BETWEEN make_interval(secs => $2) PRECEDING AND CURRENT ROW), 0\
+                    )::DOUBLE PRECISION AS mean \
                     FROM _ LEFT JOIN ping \
-                        ON end - make_interval(secs => $2) <= creation AND creation < end \
-                    WHERE mac = $1 ORDER BY end",
-                [&mac as &dyn ToSql, &secs as _, &since as _],
+                        ON endpoint - make_interval(secs => $2) <= creation AND creation < endpoint \
+                    WHERE mac = $1 ORDER BY endpoint",
+                [&mac as &(dyn ToSql + Sync), &secs as _, &since as _],
             )
             .await
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 pub mod database;
 pub mod model;
 pub mod router;

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Aggregated flow data.
-#[derive(Clone, Copy, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Flow {
     /// The upper bound of the interval.
     pub end: DateTime<Utc>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,31 +1,11 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tokio_postgres::types::{accepts, FromSql, Type};
 
+/// Aggregated flow data.
 #[derive(Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-#[serde(tag = "ty")]
-pub enum Payload {
-    Ping { flow: u16, leak: bool },
-    Open,
-    Close,
-    Bypass,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct UserMessage {
-    #[serde(rename(serialize = "ts"))]
-    pub creation: DateTime<Utc>,
-    #[serde(flatten)]
-    pub data: Payload,
-}
-
-impl<'a> FromSql<'a> for UserMessage {
-    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-        assert_eq!(*ty, Type::JSON);
-        let payload = serde_json::from_slice(raw)?;
-        Ok(payload)
-    }
-
-    accepts!(JSON);
+pub struct Flow {
+    /// The upper bound of the interval.
+    pub end: DateTime<Utc>,
+    /// Average ticks per second over this interval.
+    pub flow: f64,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Aggregated flow data.
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Copy, Deserialize, Serialize)]
 pub struct Flow {
     /// The upper bound of the interval.
     pub end: DateTime<Utc>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// Aggregated flow data.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub struct Flow {
     /// The upper bound of the interval.
     pub end: DateTime<Utc>,

--- a/src/router.rs
+++ b/src/router.rs
@@ -163,7 +163,7 @@ impl Router {
                     use tokio_stream::wrappers::UnboundedReceiverStream;
                     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
                     let last = init.last().map(|Flow { end, .. }| end).copied().unwrap();
-                    tokio::task::spawn_local(async move {
+                    tokio::spawn(async move {
                         let mut checkpoint = last;
                         loop {
                             use core::pin::pin;

--- a/src/router.rs
+++ b/src/router.rs
@@ -300,13 +300,13 @@ impl Router {
                     };
 
                     let (creation, state) = self.db.request_close(mac).await;
-                    log::info!("session {fmt} requested shutdown of unit {mac}");
+                    log::info!("session {fmt} requested shutdown of unit {mac} [{state:?}]");
 
                     let json = to_sse_close(&creation).unwrap();
                     if let Ok(receivers) = self.tx.send((mac, json)) {
-                        log::trace!("unit {mac} notified {receivers} listeners");
+                        log::trace!("unit {mac} [{state:?}] notified {receivers} listeners");
                     } else {
-                        log::trace!("no active listeners for unit {mac}");
+                        log::trace!("no active listeners for unit {mac} [{state:?}]");
                     }
 
                     let mut res = Response::new(Either::Left(Default::default()));
@@ -333,13 +333,13 @@ impl Router {
                     };
 
                     let (creation, state) = self.db.request_open(mac).await;
-                    log::info!("session {fmt} requested reset of unit {mac}");
+                    log::info!("session {fmt} requested reset of unit {mac} [{state:?}]");
 
                     let json = to_sse_open(&creation).unwrap();
                     if let Ok(receivers) = self.tx.send((mac, json)) {
-                        log::trace!("unit {mac} notified {receivers} listeners");
+                        log::trace!("unit {mac} [{state:?}] notified {receivers} listeners");
                     } else {
-                        log::trace!("no active listeners for unit {mac}");
+                        log::trace!("no active listeners for unit {mac} [{state:?}]");
                     }
 
                     let mut res = Response::new(Either::Left(Default::default()));
@@ -385,7 +385,7 @@ impl Router {
                     };
 
                     let state = self.db.register_unit(mac).await;
-                    log::info!("unit {mac} registered");
+                    log::info!("unit {mac} [{state:?}] registered");
 
                     let mut res = Response::new(Either::Left(Default::default()));
                     *res.status_mut() = match state {
@@ -405,11 +405,11 @@ impl Router {
                     };
 
                     let Ping { addr, flow: data, leak } = flow;
-                    let (_, state) = self.db.report_ping(flow).await;
+                    let (creation, state) = self.db.report_ping(flow).await;
                     if leak {
-                        log::warn!("unit {addr} reported {data} ticks with a leak");
+                        log::warn!("unit {addr} [{state:?}] reported {data} ticks with a leak at {creation}");
                     } else {
-                        log::info!("unit {addr} reported {data} ticks");
+                        log::info!("unit {addr} [{state:?}] reported {data} ticks at {creation}");
                     }
 
                     let mut res = Response::new(Either::Left(Default::default()));
@@ -430,7 +430,7 @@ impl Router {
                     };
 
                     let creation = self.db.report_bypass(addr).await;
-                    log::warn!("unit {addr} reported a manual bypass");
+                    log::warn!("unit {addr} reported a manual bypass at {creation}");
 
                     let json = to_sse_bypass(&creation).unwrap();
                     if let Ok(receivers) = self.tx.send((addr, json)) {

--- a/src/router.rs
+++ b/src/router.rs
@@ -47,11 +47,11 @@ fn to_sse_flow(value: &[Flow]) -> serde_json::Result<Bytes> {
 }
 
 fn to_sse_open(value: &DateTime<Utc>) -> serde_json::Result<Bytes> {
-    to_sse("event: open\ndata: ", value)
+    to_sse("event: reset\ndata: ", value)
 }
 
 fn to_sse_close(value: &DateTime<Utc>) -> serde_json::Result<Bytes> {
-    to_sse("event: close\ndata: ", value)
+    to_sse("event: shutdown\ndata: ", value)
 }
 
 fn to_sse_bypass(value: &DateTime<Utc>) -> serde_json::Result<Bytes> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -153,7 +153,7 @@ impl Router {
 
                     let init: Vec<_> = self
                         .db
-                        .get_user_metrics_since(mac, secs.as_secs_f64(), since)
+                        .get_user_metrics_since(mac, since, secs.as_secs_f64())
                         .await
                         .collect()
                         .await;
@@ -180,7 +180,7 @@ impl Router {
                             // Get latest metrics since our last checkpoint
                             let metrics: Vec<_> = self
                                 .db
-                                .get_user_metrics_since(mac, secs.as_secs_f64(), checkpoint)
+                                .get_user_metrics_since(mac, checkpoint, secs.as_secs_f64())
                                 .await
                                 .collect()
                                 .await;

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -98,14 +98,14 @@ async fn database_tests() -> anyhow::Result<()> {
     // Everything should thus fall under a single bucket.
     let later = Utc::now() - start;
     let secs = later.to_std().unwrap().as_secs_f64();
-    let count = db.get_user_metrics_since(addr, secs, start).await.count().await;
+    let count = db.get_user_metrics_since(addr, start, secs).await.count().await;
     assert_eq!(count, 1);
 
     // Aggregate the timestamps according to 60-second buckets. Note that it
     // is unlikely for the test suite to last more than a minute. Here, we
     // expect that the quantum has not passed yet, so there are no aggregations
     // that may be returned yet.
-    let count = db.get_user_metrics_since(addr, 60.0, start).await.count().await;
+    let count = db.get_user_metrics_since(addr, start, 60.0).await.count().await;
     assert_eq!(count, 0);
 
     // Test user login flow


### PR DESCRIPTION
This PR implements the user and system flow metrics as a "bucket-based" aggregation. A **bucket** is an interval of time (e.g., one minute) for which the database must aggregate a group of data points who `creation` timestamp is within said interval. The bucket-based aggregation of time-series data points enables greater flexibility with the granularity of the "average flow rate".

## User Metrics (`/api/metrics/user`)
The live updates from the user metrics are still forwarded via server-sent events. This time, they are no longer multiplexed according to a discriminant (i.e., `UserMessage.ty`), but by a [custom event][sse-examples] itself. This allows the client to attach differently-named event listeners to the `EventSource`.

[sse-examples]: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#examples

As mentioned earlier, the flow metrics are now aggregated based on buckets. There are no changes for open events, close events, and bypass events.

## System Metrics (`/api/metrics/system`)
Similar to the user metrics, the system metrics are forwarded via server-sent events. They are also multiplexed by [custom events][sse-examples]. The main difference between the user metrics and the system metrics is that the latter aggregates (in buckets) _all_ registered units in the system.

Given the scale of the operation, we save on bandwidth by opting _not_ to send extra events at the system-level—namely open events, close events, and bypass events. Although this is technically feasible, the implementation is much simpler otherwise.

## Starting Points and Bucket Sizes
Both endpoints require two query parameters: `since` and `secs`.

* The `since` parameter determines the "start date" of the bucket aggregation (given as a UNIX timestamp in milliseconds).
* The `secs` parameter determines the "bucket size" of the aggregation (given as the number of seconds).

The bucket aggregation starts at `since` and partitions the time-series data in buckets separated by `secs`-second intervals. Note that from `since` to the current time (i.e., [`NOW()`] in PostgreSQL), it is totally possible (and in fact the common case) that the _final_ bucket can only be partially populated. When this occurs, the data aggregation for that partial interval is omitted. The server is expected to poll the database again eventually. The current implementation simply polls every `secs` seconds.

[`NOW()`]: https://www.postgresql.org/docs/current/functions-datetime.html