### PR TITLE
feat: implement logout route

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -370,7 +370,7 @@ impl Router {
                     let fmt = uuid.simple();
                     log::info!("created new session {fmt} for unit {mac}");
 
-                    let cookie = format!("sid={fmt}; HttpOnly; SameSite=None; Secure");
+                    let cookie = format!("sid={fmt}; Path=/; HttpOnly; SameSite=None; Secure");
                     let cookie = HeaderValue::from_str(&cookie).unwrap();
 
                     let mut res = Response::new(Either::Left(Default::default()));
@@ -466,7 +466,7 @@ impl Router {
 
 
                     let mut res = Response::new(Either::Left(Full::new(body)));
-                    let cookie = HeaderValue::from_static("sid=0; Max-Age=0; HttpOnly; SameSite=None; Secure");
+                    let cookie = HeaderValue::from_static("sid=0; Max-Age=0; Path=/ HttpOnly; SameSite=None; Secure");
                     res.headers_mut().append(SET_COOKIE, cookie);
                     *res.status_mut() = status;
                     Ok(res)

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -193,6 +193,11 @@ async fn database_tests() -> anyhow::Result<()> {
     assert_eq!(state, None);
     assert!(db.get_unit_from_session(uuid::Uuid::nil()).await.is_none());
 
+    // Log the session out
+    let mac = db.delete_session(id).await.unwrap();
+    assert_eq!(mac, addr);
+    assert_eq!(db.delete_session(uuid::Uuid::nil()).await, None);
+
     drop(db);
     handle.await??;
     Ok(())


### PR DESCRIPTION
This PR implements the `DELETE /auth/logout` endpoint, which effectively deletes the session cookie. It also returns the now-deleted MAC address back to the user.